### PR TITLE
bugfix: EventStatus not being resolved before storing in update event dialog

### DIFF
--- a/LotteryApp/app/src/main/java/com/example/lotteryapp/fragments/ManageFragment.java
+++ b/LotteryApp/app/src/main/java/com/example/lotteryapp/fragments/ManageFragment.java
@@ -196,6 +196,53 @@ public class ManageFragment extends Fragment {
     }
 
     /**
+     * Resolves the event status from the event's current fields
+     *      This must be called after any create/update dialog changes are applied
+     *      and before any call to save in firebase
+     *          - so the saved status reflects the latest capacity/date state.
+     */
+    private Event.EventStatus resolveStatusForDialog(@NonNull Event event, long now) {
+        Long regStartMs = event.getRegStartMs();
+        Long regEndMs = event.getRegEndMs();
+        Long eventDateMs = event.getEventDateMs();
+
+        if (regStartMs == null || regEndMs == null || eventDateMs == null) {
+            return Event.EventStatus.REG_UPCOMING;
+        }
+
+        if (now < regStartMs) {
+            return Event.EventStatus.REG_UPCOMING;
+        }
+
+        if (now <= regEndMs) {
+            Integer waitlistCapacity = event.getWaitlistCapacity();
+            int waitlistCount = event.getWaitlistCount();
+
+            boolean hasWaitlistLimit =
+                    waitlistCapacity != null
+                            && waitlistCapacity != UNLIMITED_WAITLIST_SENTINEL;
+
+            boolean waitlistFull =
+                    hasWaitlistLimit && waitlistCount >= waitlistCapacity;
+
+            return waitlistFull ? Event.EventStatus.REG_FULL : Event.EventStatus.REG_OPEN;
+        }
+
+        if (now < eventDateMs) {
+            if (!event.hasDrawnLottery()) {
+                return Event.EventStatus.REG_CLOSED;
+            }
+
+            int occupiedSpots = event.getEnrolledCount() + event.getInvitationCount();
+            boolean eventFull = occupiedSpots >= event.getEventCapacity();
+
+            return eventFull ? Event.EventStatus.EVENT_FULL : Event.EventStatus.EVENT_OPEN;
+        }
+
+        return Event.EventStatus.EVENT_CLOSED;
+    }
+
+    /**
      * Displays a full-screen dialog for creating a new event
      *      enter event detail fields
      *      mandatory: event capacity, title, reg start/end and event date
@@ -495,16 +542,9 @@ public class ManageFragment extends Fragment {
                 }
                 newEvent.setAddress(eventAddress);
 
+                // get new event status before upserting event values to firebase
                 long now = System.currentTimeMillis();
-                if (now < localStartDateMs[0]) {
-                    newEvent.setStatus(Event.EventStatus.REG_UPCOMING);
-                } else if (now <= localEndDateMs[0]) {
-                    newEvent.setStatus(Event.EventStatus.REG_OPEN);
-                } else if (now < localEventDateMs[0]) {
-                    newEvent.setStatus(Event.EventStatus.REG_CLOSED);
-                } else {
-                    newEvent.setStatus(Event.EventStatus.EVENT_CLOSED);
-                }
+                newEvent.setStatus(resolveStatusForDialog(newEvent, now));
 
                 // eventStorage.upsertEvent got refactored to require onSuccess and onFailure listeners
                 eventStorage.upsertEvent(
@@ -901,6 +941,10 @@ public class ManageFragment extends Fragment {
 
                         event.setHasGeoConstraint(geoConstraint);
                         event.setAddress(updatedAddress);
+
+                        // get new event status before upserting event values to firebase
+                        long now = System.currentTimeMillis();
+                        event.setStatus(resolveStatusForDialog(event, now));
 
                         eventStorage.upsertEvent(
                                 event,


### PR DESCRIPTION
UpdateEventDialog in ManageFragment was missing the code to check for any changes in EventStatus based on the new Event waitlist capacity and waitlist count values,
- added helper method for resolving the current status of the event under the new (new from the update/edit) EventStatus

Solves the issue of "As an organizer, When I have an Event whose registration is full - as long as I haven't rolled my lottery yet, I want to be able to change the waitlist capacity to be greater than before so that I can accept more entrants onto the waiting list"
- Before this bugfix: setting the waitlist capacity for an event with a full waitlist (n/n) such that the waitlist count/waitlist capacity ratio changes from n/n to n/n+1, the status of the event stays as REG_FULL, and does not update to REG_OPEN
- same thing vice versa